### PR TITLE
Use a mocked Sys::Syslog for main log test

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -8,6 +8,7 @@ README.pod
 t/00-load.t
 t/01-log.t
 t/format.t
+t/lib/Sys/Syslog.pm
 t/pod-coverage.t
 t/pod.t
 xt/release/unused-vars.t

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -11,6 +11,15 @@ WriteMakefile(
       ? ('LICENSE'=> 'perl')
       : ()),
     PL_FILES            => {},
+    BUILD_REQUIRES => {
+        'Exporter'              => 0,
+        'HTTP::Request::Common' => 0,
+        'Plack'                 => '1.0029',    # OO-style Plack::Test
+        'Plack::Test'           => 0,
+        'Test::Deep'            => 0,
+        'Test::More'            => 0,
+        'Test::Warnings'        => 0,
+    },
     PREREQ_PM => {
         'Dancer2' => 0.151,
         "File::Basename" => 0,

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -30,9 +30,9 @@ WriteMakefile(
     clean               => { FILES => 'Dancer2-Logger-Syslog-*' },
     META_MERGE => {
         resources => {
-            repository => 'https://github.com/ctrlo/Dancer2-Logger-Syslog',
-            bugtracker => 'https://github.com/ctrlo/Dancer2-Logger-Syslog/issues',
-            homepage   => 'https://github.com/ctrlo/Dancer2-Logger-Syslog/',
+            repository => 'https://github.com/abeverley/Dancer2-Logger-Syslog',
+            bugtracker => 'https://github.com/abeverley/Dancer2-Logger-Syslog/issues',
+            homepage   => 'https://github.com/abeverley/Dancer2-Logger-Syslog/',
         },
     },
 

--- a/t/01-log.t
+++ b/t/01-log.t
@@ -1,8 +1,9 @@
 use strict;
 use warnings;
 use Test::More;
-
-plan tests => 8;
+use Test::Deep;
+use Test::Warnings qw/warnings :no_end_test/;
+use lib 't/lib';
 
 use Dancer2::Logger::Syslog;
 
@@ -12,15 +13,41 @@ ok defined($l), 'Dancer2::Logger::Syslog object';
 isa_ok $l, 'Dancer2::Logger::Syslog';
 can_ok $l, qw(log debug warning error);
 
-SKIP: { 
-    eval { $l->log(debug => "dummy test") };
-    skip "Need a SysLog connection to run last tests", 5 
-        if $@ =~ /no connection to syslog available/;
+my @warnings;
 
-    ok($l->log(debug => "Perl Dancer test message 1/4"), "log works");
-    ok($l->log(core => "Perl Dancer test message (core) 1/4"), 
-        "log works with 'core' level");
-    ok($l->debug("Perl Dancer test message 2/4"), "debug works");
-    ok($l->warning("Perl Dancer test message 3/4"), "warning works");
-    ok($l->error("Perl Dancer test message 4/4"), "error works");
-};
+@warnings = warnings { $l->log( debug => "Perl Dancer test message 1/5" ) };
+
+cmp_deeply \@warnings,
+  superbagof( re(qr{debug.+test.+debug.+Perl Dancer test message 1/5}) ),
+  "log method sending to debug is good"
+  or diag explain @warnings;
+
+@warnings = warnings { $l->log( core => "Perl Dancer test message core 2/5" ) };
+
+cmp_deeply \@warnings,
+  superbagof( re(qr{debug.+test.+debug.+Perl Dancer test message core 2/5}) ),
+  "log method sending to core is good"
+  or diag explain @warnings;
+
+@warnings = warnings { $l->debug("Perl Dancer test message 3/5") };
+
+cmp_deeply \@warnings,
+  superbagof( re(qr{debug.+test.+debug.+Perl Dancer test message 3/5}) ),
+  "debug method is good"
+  or diag explain @warnings;
+
+@warnings = warnings { $l->warning("Perl Dancer test message 4/5") };
+
+cmp_deeply \@warnings,
+  superbagof( re(qr{warning.+test.+warning.+Perl Dancer test message 4/5}) ),
+  "warning method is good"
+  or diag explain @warnings;
+
+@warnings = warnings { $l->error("Perl Dancer test message 5/5") };
+
+cmp_deeply \@warnings,
+  superbagof( re(qr{err.+test.+err.+Perl Dancer test message 5/5}) ),
+  "error method is good"
+  or diag explain @warnings;
+
+done_testing;

--- a/t/lib/Sys/Syslog.pm
+++ b/t/lib/Sys/Syslog.pm
@@ -1,0 +1,17 @@
+package    # make sure this stays hidden
+  Sys::Syslog;
+
+use Exporter ();
+@ISA         = qw(Exporter);
+%EXPORT_TAGS = (
+    standard => [qw(openlog syslog closelog setlogmask)],
+    extended => [qw(setlogsock)],
+);
+@EXPORT    = ( @{ $EXPORT_TAGS{standard} } );
+@EXPORT_OK = ( @{ $EXPORT_TAGS{extended} } );
+
+sub closelog { }
+sub openlog  { }
+sub syslog   { warn @_ }
+
+1;


### PR DESCRIPTION
This addresses issue #1.

An explanation of the problem:
    
The tests assumed that calling any log methods would return whatever the call to `Sys::Syslog::syslog` returns. This was fine until Dancer2 commit https://github.com/PerlDancer/Dancer2/commit/c56951f8a8a6987aaf4a7fd467fa0c9f403f748c which added engine.logger.* hooks around logging a message and so the return value of `log` and thefore also of the called `syslog` became lost causing tests to fail.
    
In order to allow tests to work this commit adds a fake local implementation of `Sys::Syslog` which simply calls `warn` with whatever list was passed into `syslog`. We catch and test the warnings with `Test::Warnings`.